### PR TITLE
Improved the configuration of the Java code formatter. It now hooks i…

### DIFF
--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -322,7 +322,7 @@
                 <version>${maven-dependency-plugin.version}</version>
                 <executions>
                     <execution>
-                        <phase>clean</phase>
+                        <phase>process-sources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>


### PR DESCRIPTION
…nto the  process-sources phase instead of the clean phase. This is more appropriate, as it is perfectly reasonable to skip clean before doing a build (which is what Travis CI does)
