### PR TITLE
Added -deprecation argument to scala compiler config

### DIFF
--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -407,6 +407,7 @@
                         <scalaVersion>${scala.version}</scalaVersion>
                         <args>
                             <arg>-target:jvm-1.8</arg>
+                            <arg>-deprecation</arg>
                         </args>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This flag makes sure that deprecation warnings are fully explained in the build log.
