### PR TITLE
Fixed problems with finalName

### DIFF
--- a/dans-java-prototype/pom.xml
+++ b/dans-java-prototype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.23</version>
+        <version>1.24</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <artifactId>dans-java-prototype</artifactId>

--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -4,7 +4,7 @@
     <groupId>nl.knaw.dans.shared</groupId>
     <artifactId>dans-prototype</artifactId>
     <name>DANS Project Protoype</name>
-    <version>1.23</version>
+    <version>1.24</version>
     <packaging>pom</packaging>
     <properties>
         <main-class>NoMainClass</main-class>
@@ -18,6 +18,7 @@
         <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
         <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+        <maven-war-plugin.version>2.6</maven-war-plugin.version>
         <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
         <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
         <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
@@ -409,6 +410,13 @@
                                 <mainClass>${main-class}</mainClass>
                             </manifest>
                         </archive>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${maven-war-plugin.version}</version>
+                    <configuration>
+                        <warName>${project.artifactId}</warName>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/dans-scala-prototype/pom.xml
+++ b/dans-scala-prototype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.23</version>
+        <version>1.24</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -18,7 +18,6 @@
         </dependency>
     </dependencies>
     <build>
-        <finalName>${project.artifactId}</finalName>
         <sourceDirectory>src/main/scala</sourceDirectory>
         <testSourceDirectory>src/test/scala</testSourceDirectory>
         <plugins>


### PR DESCRIPTION
In the EASY modules we generally want the jars to be built with a name _not_ including the version numbers but the the `tar.gz` file with the version number. Setting `finalName` in the pom just below the `build` element controls the name of the `jar`, the `war` and the `tar.gz`. If you want to differentiate it is therefore not a good idea to set `finalName` at that point. Instead, set it in the jar-plug-in configuration, the war-plugin-configuration (actually, there it is called `warName`) and in each assembly descriptor when building a `tar.gz`.
