### PR TITLE
added scala-arm to automatically close resources

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@ fixes EASY-
 #### related pull requests on github
 repo                       | PR                | note
 -------------------------- | ----------------- | ----
-easy-                      | [PR#](PRlink)     | note
+easy-                      | [PR#](PRlink)     | 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+fixes EASY-
+
+#### When applied it will
+* 
+* 
+* 
+
+#### Where should the reviewer @DANS-KNAW/easy start?
+
+#### How should this be manually tested?
+
+#### related pull requests on github
+repo                       | PR                | note
+-------------------------- | ----------------- | ----
+easy-                      | [PR#](PRlink)     | note

--- a/dans-java-prototype/pom.xml
+++ b/dans-java-prototype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.27</version>
+        <version>1.28</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <artifactId>dans-java-prototype</artifactId>

--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -4,7 +4,7 @@
     <groupId>nl.knaw.dans.shared</groupId>
     <artifactId>dans-prototype</artifactId>
     <name>DANS Project Protoype</name>
-    <version>1.27</version>
+    <version>1.28</version>
     <packaging>pom</packaging>
     <properties>
         <main-class>NoMainClass</main-class>

--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -64,6 +64,7 @@
         <scalarx.version>0.26.0</scalarx.version>
         <scala-xml.version>1.0.5</scala-xml.version>
         <scalaj.version>1.1.4</scalaj.version>
+        <scala-arm.version>2.0.0-M1</scala-arm.version>
         <scala-test.version>2.2.1</scala-test.version>
         <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
         <scalamock.version>3.2.1</scalamock.version>
@@ -239,6 +240,11 @@
                 <groupId>org.scala-lang.modules</groupId>
                 <artifactId>scala-xml_2.11</artifactId>
                 <version>${scala-xml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jsuereth</groupId>
+                <artifactId>scala-arm_2.11</artifactId>
+                <version>${scala-arm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scalatest</groupId>

--- a/dans-scala-prototype/pom.xml
+++ b/dans-scala-prototype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.27</version>
+        <version>1.28</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
fixes EASY dependencies
#### When applied it will
- allow sub projects to omit a version number for scala-arm
#### Where should the reviewer @DANS-KNAW/easy start?
#### How should this be manually tested?
- `mvn clean install` of easy-build with component versions listed below
#### related pull requests on github

| repo | PR | note |
| --- | --- | --- |
| easy-ingest | [#47](https://github.com/DANS-KNAW/easy-ingest/pull/47) | depends on this change |
| easy-bag-store | [#4](https://github.com/DANS-KNAW/easy-bag-store/pull/4) | idem |
|  |  | more will follow |
