### PR TITLE
upgrade scala-arm to 2.0-RC1

### DIFF
--- a/dans-java-prototype/pom.xml
+++ b/dans-java-prototype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.29</version>
+        <version>1.30</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <artifactId>dans-java-prototype</artifactId>

--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -4,7 +4,7 @@
     <groupId>nl.knaw.dans.shared</groupId>
     <artifactId>dans-prototype</artifactId>
     <name>DANS Project Protoype</name>
-    <version>1.29</version>
+    <version>1.30</version>
     <packaging>pom</packaging>
     <properties>
         <main-class>NoMainClass</main-class>

--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -65,7 +65,7 @@
         <scalarx.version>0.26.0</scalarx.version>
         <scala-xml.version>1.0.5</scala-xml.version>
         <scalaj.version>1.1.4</scalaj.version>
-        <scala-arm.version>2.0.0-M1</scala-arm.version>
+        <scala-arm.version>2.0-RC1</scala-arm.version>
         <scala-test.version>2.2.1</scala-test.version>
         <scalatest-maven-plugin.version>1.0</scalatest-maven-plugin.version>
         <scalamock.version>3.2.1</scalamock.version>

--- a/dans-scala-prototype/pom.xml
+++ b/dans-scala-prototype/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.29</version>
+        <version>1.30</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
#### When applied it will
- upgrade the scala-arm version to 2.0-RC1.
- Note that Maven defines this version as being older than 2.0.0-M1, although 2.0-RC1 resembles the current state of the repository.
