### PR TITLE
Scallop upgrade

### DIFF
--- a/dans-java-prototype/pom.xml
+++ b/dans-java-prototype/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.33</version>
+        <version>1.34</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <artifactId>dans-java-prototype</artifactId>

--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -62,7 +62,7 @@
         <scala.version>2.11.7</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala-maven-plugin.version>3.2.1</scala-maven-plugin.version>
-        <scallop.version>2.0.2</scallop.version>
+        <scallop.version>2.0.5</scallop.version>
         <scalarx.version>0.26.0</scalarx.version>
         <scala-xml.version>1.0.5</scala-xml.version>
         <scalaj.version>1.1.4</scalaj.version>

--- a/dans-prototype/pom.xml
+++ b/dans-prototype/pom.xml
@@ -4,7 +4,7 @@
     <groupId>nl.knaw.dans.shared</groupId>
     <artifactId>dans-prototype</artifactId>
     <name>DANS Project Protoype</name>
-    <version>1.33</version>
+    <version>1.34</version>
     <packaging>pom</packaging>
     <properties>
         <main-class>NoMainClass</main-class>
@@ -62,7 +62,7 @@
         <scala.version>2.11.7</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala-maven-plugin.version>3.2.1</scala-maven-plugin.version>
-        <scallop.version>0.9.5</scallop.version>
+        <scallop.version>2.0.2</scallop.version>
         <scalarx.version>0.26.0</scalarx.version>
         <scala-xml.version>1.0.5</scala-xml.version>
         <scalaj.version>1.1.4</scalaj.version>

--- a/dans-scala-prototype/pom.xml
+++ b/dans-scala-prototype/pom.xml
@@ -3,11 +3,10 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-prototype</artifactId>
-        <version>1.33</version>
+        <version>1.34</version>
         <relativePath>../dans-prototype</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>nl.knaw.dans.shared</groupId>
     <artifactId>dans-scala-prototype</artifactId>
     <name>DANS Scala Project Protoype</name>
     <packaging>pom</packaging>


### PR DESCRIPTION
fixes EASY-1049

#### When applied it will
* Upgrade Scallop to version 2.0.5 in `dans-prototype`
* Increment version numbers of `dans-prototype`, `dans-java-prototype` and `dans-scala-prototype`
* remove an unnecessary `groupId` (according to IntelliJ)

#### Where should the reviewer @DANS-KNAW/easy start?
`pom.xml` in `dans-prototype`

## @janvanmansum please merge and deploy on Artifactory!